### PR TITLE
ci: support mypy 0.9xx

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         run: python -m pip install -U pip
 
       - name: Install dependencies
-        run: python -m pip install toml packaging rich wheel pytest pytest-cov pytest-mock backports.cached-property
+        run: python -m pip install toml packaging rich wheel pytest pytest-cov pytest-mock backports.cached-property types-toml
 
       - name: Install mypy
         run: python -m pip install mypy

--- a/trampolim/_build.py
+++ b/trampolim/_build.py
@@ -58,7 +58,7 @@ class TrampolimWarning(Warning):
 
 def load_file_module(name: str, path: str) -> object:
     spec = importlib.util.spec_from_file_location(name, path)
-    if not spec.loader:  # pragma: no cover
+    if not spec or not spec.loader:  # pragma: no cover
         raise ImportError(f'Unable to import `{path}`: no loader')
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore


### PR DESCRIPTION
I'd recommend running mypy from pre-commit (or maybe something like nox) as it's very important to fully control MyPy's environment, and usually nice to have it pinned as well (say with pre-commit). (See the recommendation here, for an example: https://scikit-hep.org/developer/style#type-checking )