### PR TITLE
ci: use nox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,24 +36,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.py }}
-
-      - name: Update pip
-        run: python -m pip install -U pip
-
-      - name: Install dependencies
-        run: python -m pip install tomli packaging rich wheel pytest pytest-cov pytest-mock backports.cached-property pep621
+      - uses: excitedleigh/setup-nox@v2.0.0
 
       - name: Run tests
-        run: python -m pytest --cov
+        run: nox -s tests-${{ matrix.py }}
 
       - uses: codecov/codecov-action@v1
         if: ${{ always() }}
         env:
-          PYTHON: ${{ matrix.python }}
+          PYTHON: ${{ matrix.py }}
         with:
           flags: tests
           env_vars: PYTHON
@@ -64,19 +55,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Update pip
-        run: python -m pip install -U pip
-
-      - name: Install dependencies
-        run: python -m pip install tomli packaging rich wheel pytest pytest-cov pytest-mock backports.cached-property pep621
-
-      - name: Install mypy
-        run: python -m pip install mypy
-
       - name: Run check for type
-        run: python -m mypy -p trampolim
+        run: pipx run nox -s type

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+
+import nox
+
+
+nox.options.sessions = ['lint', 'type', 'tests']
+
+
+@nox.session(reuse_venv=True)
+def lint(session):
+    """
+    Run the linter.
+    """
+    session.install('pre-commit')
+    session.run('pre-commit', 'run', '--all-files', *session.posargs)
+
+
+@nox.session(python=['3.7', '3.8', '3.9'], reuse_venv=True)
+def tests(session):
+    """
+    Run the unit and regular tests.
+    """
+
+    htmlcov_output = os.path.join(session.virtualenv.location, 'htmlcov')
+    xmlcov_output = os.path.join(session.virtualenv.location, f'coverage-{session.python}.xml')
+
+    session.install(
+        'tomli',
+        'packaging',
+        'rich',
+        'wheel',
+        'pytest',
+        'pytest-cov',
+        'pytest-mock',
+        'backports.cached-property',
+        'pep621',
+    )
+
+    session.run(
+        'pytest', '--cov', '--cov-config', 'setup.cfg',
+        f'--cov-report=html:{htmlcov_output}',
+        f'--cov-report=xml:{xmlcov_output}',
+        '--showlocals',
+        '-vv',
+        '--durations=1',
+        'tests/', *session.posargs
+    )
+
+
+@nox.session(reuse_venv=True)
+def type(session):
+    session.install('mypy')
+    session.run('mypy', '-p', 'trampolim', *session.posargs)
+
+
+@nox.session(reuse_venv=True)
+def docs(session):
+    """
+    Build the docs. Pass "serve" to serve.
+    """
+
+    session.install('.[docs]')
+    session.chdir('docs')
+    session.run('sphinx-build', '-M', 'html', '.', '_build')
+
+    if session.posargs:
+        if 'serve' in session.posargs:
+            print('Launching docs at http://localhost:8000/ - use Ctrl-C to quit')
+            session.run('python', '-m', 'http.server', '8000', '-d', '_build/html')
+        else:
+            print('Unsupported argument to docs')
+
+
+@nox.session
+def build(session):
+    """
+    Build an SDist and wheel.
+    """
+
+    session.install('build')
+    session.run('python', '-m', 'build', *session.posargs)


### PR DESCRIPTION
This allows the CI to be run locally with `nox -s tests-3.9` or
`nox -s type` or `nox -s docs -- serve`, for example. Removes dependence on
GitHub Actions.

(I already added this to do local testing, thought it might be useful to others)
