### PR TITLE
nox: type: improve strictness, check 3.7 & 3.9

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -51,8 +51,9 @@ def tests(session):
 
 @nox.session(reuse_venv=True)
 def type(session):
-    session.install('mypy')
-    session.run('mypy', '-p', 'trampolim', *session.posargs)
+    session.install('mypy', 'packaging', 'tomli', 'rich', 'backports.cached_property')
+    session.run('mypy', '--python-version=3.7', '--package=trampolim', *session.posargs)
+    session.run('mypy', '--python-version=3.9', '--package=trampolim', *session.posargs)
 
 
 @nox.session(reuse_venv=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,8 +4,15 @@ max-complexity = 10
 extend-ignore = E203
 
 [mypy]
-ignore_missing_imports = True
+warn_unused_configs = True
 strict = True
+python_version = 3.7
+
+[mypy-wheel.*]
+ignore_missing_imports = True
+
+[mypy-pep621.*]
+ignore_missing_imports = True
 
 [isort]
 line_length = 127


### PR DESCRIPTION
Touching up the type checking strictness a bit, also checking both ends. I really like pyproject.toml config for mypy much better, but left it in setup.cfg for now.
