### PR TITLE
ci: add Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,10 @@ jobs:
           - macos
           - windows
         py:
-          - 3.9
-          - 3.8
-          - 3.7
+          - "3.10"
+          - "3.9"
+          - "3.8"
+          - "3.7"
 #          - pypy3
 
     steps:
@@ -39,7 +40,7 @@ jobs:
       - uses: excitedleigh/setup-nox@v2.0.0
 
       - name: Run tests
-        run: nox -s test-${{ matrix.py }}
+        run: nox --force-color -s test-${{ matrix.py }}
 
       - uses: codecov/codecov-action@v1
         if: ${{ always() }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def lint(session):
     session.run('pre-commit', 'run', '--all-files', *session.posargs)
 
 
-@nox.session(python=['3.7', '3.8', '3.9'], reuse_venv=True)
+@nox.session(python=['3.7', '3.8', '3.9', '3.10'], reuse_venv=True)
 def test(session):
     """
     Run the unit and regular tests.


### PR DESCRIPTION
Rather expecting this to fail, as it's failing elsewhere. But I'm getting a somewhat unrelated `pep621.ConfigurationError: Missing version field` error, so maybe it's not related. We'll see. Edit: Appears to be something else. pep621 is missing release notes for 0.4.0, btw.