### PR TITLE
nox: fix noxfile without arguments

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ import os
 import nox
 
 
-nox.options.sessions = ['lint', 'type', 'tests']
+nox.options.sessions = ['lint', 'type', 'test']
 
 
 @nox.session(reuse_venv=True)


### PR DESCRIPTION
Didn't catch this earlier, but it breaks `nox -l`.