### PR TITLE
tests: use tmp_path (PyTest 3.9+)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
   'wheel',
-  'pytest',
+  'pytest>=3.9.1',
   'pytest-cov',
   'pytest-mock',
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,6 @@
 import contextlib
 import os
 import pathlib
-import shutil
-import tempfile
 
 import pytest
 
@@ -23,29 +21,6 @@ def cd_package(package):
         yield package_path
     finally:
         os.chdir(cur_dir)
-
-
-@pytest.fixture
-def tmp_dir():
-    path = tempfile.mkdtemp(prefix='trampolim-test-')
-
-    try:
-        yield pathlib.Path(path)
-    finally:
-        shutil.rmtree(path)
-
-
-@pytest.fixture(scope='session')
-def tmp_dir_session():
-    path = tempfile.mkdtemp(prefix='trampolim-test-')
-
-    try:
-        yield pathlib.Path(path)
-    finally:
-        try:
-            shutil.rmtree(path)
-        except PermissionError:  # pragma: no cover
-            pass  # this sometimes fails on windows :/
 
 
 @pytest.fixture
@@ -71,17 +46,19 @@ def generate_package_fixture(package):
 
 def generate_sdist_fixture(package):
     @pytest.fixture(scope='session')
-    def fixture(tmp_dir_session):
+    def fixture(tmp_path_factory):
+        tmp_path_sdist = tmp_path_factory.mktemp('sdist_package')
         with cd_package(package):
-            return tmp_dir_session / trampolim.build_sdist(tmp_dir_session)
+            return tmp_path_sdist / trampolim.build_sdist(tmp_path_sdist)
     return fixture
 
 
 def generate_wheel_fixture(package):
     @pytest.fixture(scope='session')
-    def fixture(tmp_dir_session):
+    def fixture(tmp_path_factory):
+        tmp_path_wheel = tmp_path_factory.mktemp('wheel_package')
         with cd_package(package):
-            return tmp_dir_session / trampolim.build_wheel(tmp_dir_session)
+            return tmp_path_wheel / trampolim.build_wheel(tmp_path_wheel)
     return fixture
 
 

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -119,10 +119,10 @@ def tests_src_layout(package_src_layout, sdist_src_layout):
     )
 
 
-def test_overwrite_version(monkeypatch, package_no_version, tmp_dir):
+def test_overwrite_version(monkeypatch, package_no_version, tmp_path):
     monkeypatch.setenv('TRAMPOLIM_VCS_VERSION', '1.0.0+custom')
 
-    t = tarfile.open(tmp_dir / trampolim.build_sdist(tmp_dir), 'r')
+    t = tarfile.open(tmp_path / trampolim.build_sdist(tmp_path), 'r')
     pkginfo = t.extractfile('no-version-1.0.0+custom/PKG-INFO').read().decode()
     assert pkginfo == textwrap.dedent('''
         Metadata-Version: 2.1

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -85,10 +85,10 @@ def test_src_layout(package_src_layout, wheel_src_layout):
         }
 
 
-def test_overwrite_version(monkeypatch, package_no_version, tmp_dir):
+def test_overwrite_version(monkeypatch, package_no_version, tmp_path):
     monkeypatch.setenv('TRAMPOLIM_VCS_VERSION', '1.0.0+custom')
 
-    with wheel.wheelfile.WheelFile(tmp_dir / trampolim.build_wheel(tmp_dir), 'r') as w:
+    with wheel.wheelfile.WheelFile(tmp_path / trampolim.build_wheel(tmp_path), 'r') as w:
         metadata = w.read('no_version-1.0.0+custom.dist-info/METADATA').decode()
     assert metadata == textwrap.dedent('''
         Metadata-Version: 2.1


### PR DESCRIPTION
In #20, from local testing, it is clearly an empty folder that is hanging up on Windows. I don't think it's a critical problem; I don't think it's reproducible when running non-test code. As a nicer fix, we can move to pytest's built in (3.9+) fixtures for making temporary directories (test level and session level). These stick around for ~3 days or the last three sessions, for easier debuging, and therefore don't trigger this issue. Adding `-Wd` didn't produce any unclosed file warnings on #20, so I think it's safe.
